### PR TITLE
Build and label update

### DIFF
--- a/Dockerfile.admixture
+++ b/Dockerfile.admixture
@@ -15,4 +15,6 @@ COPY --chmod=0555 --from=builder \
 
 COPY --chmod=0555 src/test/${RUN_CMD}.sh /test.sh
 
+ENTRYPOINT [ "admixture" ]
+
 LABEL org.opencontainers.image.description="ADMIXTURE software for global ancestry calculations."

--- a/Dockerfile.metal
+++ b/Dockerfile.metal
@@ -34,4 +34,6 @@ COPY --chmod=0555 --from=builder /usr/src/${RUN_CMD}/build/bin/metal \
 					/usr/local/bin/
 COPY --chmod=0555 src/test/${RUN_CMD}.sh /test.sh
 
+ENTRYPOINT [ "metal" ]
+
 LABEL org.opencontainers.image.description="${RUN_CMD} software for meta analysis."

--- a/Dockerfile.rfmix
+++ b/Dockerfile.rfmix
@@ -32,4 +32,6 @@ ARG BUILD_TIME
 COPY --chmod=0555 --from=builder /rfmix/rfmix /usr/local/bin/rfmix
 COPY --chmod=0555 src/test/${RUN_CMD}.sh /test.sh
 
+ENTRYPOINT [ "rfmix" ]
+
 LABEL org.opencontainers.image.description="RFMix v2 software for local ancestry inference."


### PR DESCRIPTION
- place each package on its own line to facilitate diffs
- clean after package install (except on discarded builder)
- do not time-stamp the base image (to avoid rebuilds)
- migrate labels to bottom of Dockerfile to reduce rebuilds where time stamps are set
- i nstall runtime dependencies in the base image first, so they can be discovered by any build configuration or dependency check   (this in some cases avoids building vendored libraries)
- include the runtime libraries in the base image where -dev libraries are included in the builder
- add entry points