### PR TITLE
Build update

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -3,6 +3,9 @@ name: Docker Image CI
 on:
   pull_request:
     branches: [ "main" ]
+  push:
+    tags-ignore: ["*"]
+  workflow_dispatch:
 
 jobs:
 
@@ -12,10 +15,13 @@ jobs:
 
     steps:
     - name: 'Checkout Actions'
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 5
+        fetch-tags: true
 
     - name: 'Build the Docker image'
-      run: make docker
+      run: IMAGE_REPO=ghcr.io make docker
 
     - name: 'Test the Docker image'
-      run: make docker_test
+      run: IMAGE_REPO=ghcr.io make docker_test

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
+  workflow_dispatch:
 
 jobs:
 
@@ -13,7 +14,7 @@ jobs:
 
     steps:
     - name: 'Checkout Actions'
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: 'Login to GitHub Container Registry'
       uses: docker/login-action@v3
@@ -23,10 +24,10 @@ jobs:
         password: ${{secrets.GITHUB_TOKEN}}
 
     - name: 'Build the Docker image'
-      run: make docker
+      run: IMAGE_REPO="ghcr.io" make docker
 
     - name: 'Test the Docker image'
-      run: make docker_test
+      run: IMAGE_REPO="ghcr.io" make docker_test
 
     - name: 'Release the Docker image'
-      run: IMAGE_REPOSITORY=ghcr.io make docker_release
+      run: IMAGE_REPO="ghcr.io" make docker_release

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,16 @@
 # SPDX-License-Identifier: GPL-2.0
-ARG BASE_IMAGE
-FROM $BASE_IMAGE as builder
-
-LABEL org.opencontainers.image.description="Base C/C++ container"
+ARG BASE
+FROM $BASE
 
 RUN apt -y update -qq && apt -y upgrade && \
 	DEBIAN_FRONTEND=noninteractive apt -y install \
-	ca-certificates curl \
-  gcc g++ wget 
+	--no-install-recommends --no-install-suggests \
+		ca-certificates \
+		curl \
+		gcc \
+		g++ \
+		wget \
+	&& \
+	apt -y clean && rm -rf /var/lib/apt/lists/* /tmp/*
+
+LABEL org.opencontainers.image.description="Base C/C++ container"

--- a/Dockerfile.admixture
+++ b/Dockerfile.admixture
@@ -1,18 +1,18 @@
 # SPDX-License-Identifier: GPL-2.0
-ARG BASE_IMAGE
-FROM $BASE_IMAGE as builder
+ARG BASE
+FROM $BASE as builder
 
-LABEL org.opencontainers.image.description="ADMIXTURE software for global ancestry calculations."
-
-WORKDIR /ADMIXTURE
+WORKDIR /usr/src
 RUN wget https://dalexander.github.io/admixture/binaries/admixture_linux-1.3.0.tar.gz && \
     tar xf admixture_linux-1.3.0.tar.gz
 
-FROM $BASE_IMAGE as runtime
-
+FROM $BASE
+ARG BASE
 ARG RUN_CMD
 
-COPY --chmod=0555 --from=builder /ADMIXTURE/dist/admixture_linux-1.3.0/admixture /usr/local/bin/
+COPY --chmod=0555 --from=builder \
+	/usr/src/dist/admixture_linux-1.3.0/admixture /usr/local/bin/
 
-ARG TEST="/test.sh"
-COPY --chmod=0555 src/test/$RUN_CMD.sh ${TEST}
+COPY --chmod=0555 src/test/${RUN_CMD}.sh /test.sh
+
+LABEL org.opencontainers.image.description="ADMIXTURE software for global ancestry calculations."

--- a/Dockerfile.admixture
+++ b/Dockerfile.admixture
@@ -15,4 +15,6 @@ COPY --chmod=0555 --from=builder \
 
 COPY --chmod=0555 src/test/${RUN_CMD}.sh /test.sh
 
+ENTRYPOINT [ "admixture" ]
+
 LABEL org.opencontainers.image.description="ADMIXTURE software for global ancestry calculations."

--- a/Dockerfile.metal
+++ b/Dockerfile.metal
@@ -1,28 +1,37 @@
 # SPDX-License-Identifier: GPL-2.0
-ARG BASE_IMAGE
-FROM $BASE_IMAGE as builder
-
-LABEL org.opencontainers.image.description="METAL software for meta analysis."
-
-RUN apt -y update -qq && apt -y upgrade && \
-	DEBIAN_FRONTEND=noninteractive apt -y install \
-	cmake make \
-  git zlib1g-dev
-
-RUN git clone https://github.com/statgen/METAL.git
-
-WORKDIR /METAL
-RUN mkdir build && cd build && \
-	cmake -DCMAKE_BUILD_TYPE=Release .. && \
-	make && \
-	make test && \
-	make install
-
-FROM $BASE_IMAGE as runtime
-
+ARG BASE
+FROM $BASE as base
+ARG BASE
 ARG RUN_CMD
 
-COPY --chmod=0555 --from=builder /METAL/build/bin/metal /usr/local/bin/
+RUN apt -y update -qq && DEBIAN_FRONTEND=noninteractive apt -y install \
+	--no-install-recommends --no-install-suggests \
+		zlib1g \
+	&& \
+	apt -y clean && rm -rf /var/lib/apt/lists/* /tmp/*
 
-ARG TEST="/test.sh"
-COPY --chmod=0555 src/test/$RUN_CMD.sh ${TEST}
+FROM base as builder
+
+RUN apt -y update -qq && DEBIAN_FRONTEND=noninteractive apt -y install \
+	--no-install-recommends --no-install-suggests \
+		cmake \
+		make \
+		git \
+		zlib1g-dev
+
+WORKDIR /usr/src
+
+RUN git clone https://github.com/statgen/${RUN_CMD}.git
+RUN cd ${RUN_CMD} && mkdir build && cd build && \
+	cmake -DCMAKE_BUILD_TYPE=Release .. && make && \
+	make test && make install
+
+FROM base
+ARG BASE
+ARG RUN_CMD
+
+COPY --chmod=0555 --from=builder /usr/src/${RUN_CMD}/build/bin/metal \
+					/usr/local/bin/
+COPY --chmod=0555 src/test/${RUN_CMD}.sh /test.sh
+
+LABEL org.opencontainers.image.description="${RUN_CMD} software for meta analysis."

--- a/Dockerfile.metal
+++ b/Dockerfile.metal
@@ -34,4 +34,6 @@ COPY --chmod=0555 --from=builder /usr/src/${RUN_CMD}/build/bin/metal \
 					/usr/local/bin/
 COPY --chmod=0555 src/test/${RUN_CMD}.sh /test.sh
 
+ENTRYPOINT [ "metal" ]
+
 LABEL org.opencontainers.image.description="${RUN_CMD} software for meta analysis."

--- a/Dockerfile.rfmix
+++ b/Dockerfile.rfmix
@@ -32,4 +32,6 @@ ARG BUILD_TIME
 COPY --chmod=0555 --from=builder /rfmix/rfmix /usr/local/bin/rfmix
 COPY --chmod=0555 src/test/${RUN_CMD}.sh /test.sh
 
+ENTRYPOINT [ "rfmix" ]
+
 LABEL org.opencontainers.image.description="RFMix v2 software for local ancestry inference."

--- a/Dockerfile.rfmix
+++ b/Dockerfile.rfmix
@@ -1,30 +1,35 @@
 # SPDX-License-Identifier: GPL-2.0
-ARG BASE_IMAGE
-FROM $BASE_IMAGE as builder
+ARG BASE
+FROM $BASE as base
 
-LABEL org.opencontainers.image.description="RFMix v2 software for local ancestry inference."
+RUN apt -y update -qq && DEBIAN_FRONTEND=noninteractive apt -y install \
+	--no-install-recommends --no-install-suggests \
+		bcftools \
+		libpthread-stubs0-dev \
+	&& \
+	apt -y clean && rm -rf /var/lib/apt/lists/* /tmp/*
 
-RUN apt -y update && apt -y upgrade && \
-  DEBIAN_FRONTEND=noninteractive apt -y install \
-  autoconf git \
-  make libpthread-stubs0-dev
+FROM base as builder
 
-RUN git clone https://github.com/slowkoni/rfmix.git
+RUN apt -y update -qq && DEBIAN_FRONTEND=noninteractive apt -y install \
+	--no-install-recommends --no-install-suggests \
+		autoconf \
+		automake \
+		git \
+		make \
+        && \
+        apt -y clean && rm -rf /var/lib/apt/lists/* /tmp/*
 
-RUN cd rfmix && \
-  autoreconf --force --install && \
-  ./configure && \
-  make
+RUN git clone https://github.com/slowkoni/rfmix.git && \
+	cd rfmix && autoreconf --force --install && ./configure && make
 
-FROM $BASE_IMAGE as runtime
-
+FROM base as runtime
+ARG BASE
 ARG RUN_CMD
-
-RUN apt -y update && apt -y upgrade && \
-  DEBIAN_FRONTEND=noninteractive apt -y install \
-  bcftools
+ARG BUILD_REPO
+ARG BUILD_TIME
 
 COPY --chmod=0555 --from=builder /rfmix/rfmix /usr/local/bin/rfmix
+COPY --chmod=0555 src/test/${RUN_CMD}.sh /test.sh
 
-ARG TEST="/test.sh"
-COPY --chmod=0555 src/test/$RUN_CMD.sh ${TEST}
+LABEL org.opencontainers.image.description="RFMix v2 software for local ancestry inference."

--- a/Makefile
+++ b/Makefile
@@ -1,44 +1,62 @@
 # SPDX-License-Identifier: GPL-2.0
 
+IMAGE_REPO ?=
 ORG_NAME ?= hihg-um
 OS_BASE ?= ubuntu
 OS_VER ?= 24.04
 
-IMAGE_REPOSITORY ?=
-
 TOOLS := admixture metal rfmix
 
-DOCKER_BUILD_ARGS :=
-DOCKER_TAG ?= $(shell git describe --tags --broken --dirty --all --long | \
-		sed "s,heads/,," | sed "s,tags/,," | \
-		sed "s,remotes/pull/.*/,," \
-		)_$(shell uname -m)_$(shell uname -s | \
-		tr '[:upper:]' '[:lower:]')
-DOCKER_BASE ?= $(patsubst docker-%,%,$(shell basename \
-		`git remote --verbose | grep origin | grep fetch | \
-		cut -f2 | cut -d ' ' -f1` | sed 's/.git//'))
+ifneq ($(IMAGE_REPO),)
+    DOCKER_REPO := $(IMAGE_REPO)/$(ORG_NAME)
+else
+    DOCKER_REPO := $(ORG_NAME)
+endif
+
+GIT_REPO := $(shell git remote get-url origin | sed 's,git@,,' | sed 's,:,/,')
+GIT_REPO_TAIL := $(shell basename $(GIT_REPO) | sed 's/.git//' | \
+			sed 's/docker-//')
+GIT_TAG_HEAD ?= $(shell git describe --exact-match --tags --dirty 2>/dev/null)
+GIT_TAG_LAST ?= $(shell git describe --abbrev=0 --always --tags)
+
+ifeq ($(GIT_TAG_HEAD),$(GIT_TAG_LAST))
+        GIT_LATEST := true
+        GIT_TAG := $(GIT_TAG_HEAD)
+        GIT_REV := $(shell git log -1 --pretty=format:%h)
+        DOCKER_TAG := $(GIT_TAG)
+else
+        GIT_TAG := $(GIT_TAG_LAST)
+        GIT_CNT := $(shell git rev-list $(GIT_TAG)..HEAD --count)
+        GIT_REV := $(shell git describe --broken --dirty --all --long | \
+			sed "s,heads/,," | sed "s,tags/,," | \
+			sed "s,remotes/pull/.*/,,")
+        DOCKER_TAG := $(GIT_REV)
+endif
+
+DOCKER_BASE := $(DOCKER_REPO)/$(GIT_REPO_TAIL):$(DOCKER_TAG)
 DOCKER_IMAGES := $(TOOLS:=\:$(DOCKER_TAG))
+DOCKER_IMAGES_TEST := $(DOCKER_IMAGES)
+
+DOCKER_BUILD_TIME := "$(shell date -u)"
+DOCKER_BUILD_OPTS ?= "--progress=plain"
+
 SIF_IMAGES := $(TOOLS:=_$(DOCKER_TAG).sif)
 
 IMAGE_TEST := /test.sh
 
-.PHONY: apptainer_clean apptainer_test \
-	docker_base docker_clean docker_test docker_release $(TOOLS)
+.PHONY: apptainer_clean apptainer_distclean apptainer_test \
+	docker_base docker_clean docker_release $(TOOLS)
 
 help:
 	@echo "Targets: all build clean test release"
 	@echo "         docker docker_base docker_clean docker_test docker_release"
-	@echo "         apptainer apptainer_clean apptainer_test"
+	@echo "         apptainer apptainer_clean apptainer_distclean apptainer_test"
 	@echo
 	@echo "Docker container(s):"
-	@for f in $(DOCKER_IMAGES); do \
-		printf "\t$$f\n"; \
-	done
+	@for f in $(DOCKER_IMAGES); do printf "\t$$f\n"; done
 	@echo
 	@echo "Apptainer(s):"
-	@for f in $(SIF_IMAGES); do \
-		printf "\t$$f\n"; \
-	done
+	@for f in $(SIF_IMAGES); do printf "\t$$f\n"; done
 	@echo
 
 all: clean build test
@@ -55,62 +73,62 @@ test: docker_test apptainer_test
 docker: docker_base $(TOOLS)
 
 $(TOOLS):
-	@echo "Building Docker container: $(ORG_NAME)/$@:$(DOCKER_TAG)"
+	@echo "Building Docker container: $(DOCKER_REPO)/$@:$(DOCKER_TAG)"
 	@docker build \
-		$(DOCKER_BUILD_ARGS) \
+		$(DOCKER_BUILD_OPTS) \
 		-f Dockerfile.$@ \
-		-t $(ORG_NAME)/$@:$(DOCKER_TAG) \
-		--build-arg BASE_IMAGE=$(ORG_NAME)/$(DOCKER_BASE):$(DOCKER_TAG) \
+		-t $(DOCKER_REPO)/$@:$(DOCKER_TAG) \
+		--build-arg BASE=$(DOCKER_BASE) \
 		--build-arg RUN_CMD=$@ \
+		--build-arg BUILD_REPO=$(DOCKER_REPO)/$@:$(DOCKER_TAG) \
+		--build-arg BUILD_TIME=$(DOCKER_BUILD_TIME) \
 		.
-
-	$(if $(shell git fetch 2>&1; git diff @{upstream} 2>&1),,docker \
-		tag $(ORG_NAME)/$@:$(DOCKER_TAG) $(ORG_NAME)/$@:latest)
+	$(if $(GIT_LATEST), \
+		@docker tag \
+		$(DOCKER_REPO)/$@:$(DOCKER_TAG) $(DOCKER_REPO)/$@:latest)
 
 docker_base:
-	@echo "Building Docker base: $(ORG_NAME)/$(DOCKER_BASE):$(DOCKER_TAG)"
-	@docker build -t $(ORG_NAME)/$(DOCKER_BASE):$(DOCKER_TAG) \
-		$(DOCKER_BUILD_ARGS) \
-		--build-arg BASE_IMAGE=$(OS_BASE):$(OS_VER) \
+	@echo "Building Docker base: $(DOCKER_BASE)"
+	@docker build -t $(DOCKER_BASE) \
+		$(DOCKER_BUILD_OPTS) \
+		--build-arg BASE=$(OS_BASE):$(OS_VER) \
+		--build-arg GIT_REPO=$(GIT_REPO) \
+		--build-arg GIT_REV=$(GIT_REV) \
+		--build-arg GIT_TAG=$(GIT_TAG) \
+		--build-arg BUILD_REPO=$(DOCKER_BASE) \
 		.
+	@docker inspect $(DOCKER_BASE)
 
 docker_clean:
+	@docker builder prune -f 1> /dev/null 2>& 1
 	@for f in $(TOOLS); do \
-		docker rmi -f $(ORG_NAME)/$$f:$(DOCKER_TAG) 2>/dev/null; \
-		if [ -z "`git fetch 2>&1; \
-			git diff @{upstream} 2>&1`" ]; then \
-				docker rmi -f $(ORG_NAME)/$$f:latest \
-			       		2>/dev/null; \
-		fi \
+		docker rmi -f $(DOCKER_REPO)/$$f:$(DOCKER_TAG) 1> /dev/null 2>& 1; \
 	done
-	@docker rmi -f $(ORG_NAME)/$(DOCKER_BASE):$(DOCKER_TAG) 2>/dev/null
-	@docker builder prune -f 2>/dev/null;
+	@docker rmi -f $(DOCKER_BASE) 1> /dev/null 2>& 1
 
-docker_test:
-	@for f in $(DOCKER_IMAGES); do \
-		echo; echo "Testing Docker container: $(ORG_NAME)/$$f"; \
-		docker run -t \
-			-v /etc/passwd:/etc/passwd:ro \
-			-v /etc/group:/etc/group:ro \
-			--entrypoint=$(IMAGE_TEST) \
-			--user=$(shell echo `id -u`):$(shell echo `id -g`) \
-			$(ORG_NAME)/$$f; \
-	done
+$(DOCKER_IMAGES_TEST):
+	@echo
+	@echo "Testing Docker container: $(DOCKER_REPO)/$@"
+	@docker run -t \
+		--entrypoint=$(IMAGE_TEST) \
+		$(DOCKER_REPO)/$@
+
+docker_test: $(DOCKER_IMAGES_TEST)
 
 docker_release:
-	@for f in $(DOCKER_IMAGES); do \
-		docker tag $(ORG_NAME)/$$f \
-			$(IMAGE_REPOSITORY)/$(ORG_NAME)/$$f; \
-		docker push $(IMAGE_REPOSITORY)/$(ORG_NAME)/$$f; \
-	done
+	$(if $(GIT_LATEST), \
+		for f in $(GIT_REPO_TAIL) $(TOOLS); do \
+			docker push $(DOCKER_REPO)/$$f:$(DOCKER_TAG); \
+			docker push $(DOCKER_REPO)/$$f:latest; done, \
+		$(info "Cannot push untagged build: $(GIT_TAG):$(GIT_REV)"))
 
 # Apptainer
 apptainer: $(SIF_IMAGES)
 
 $(SIF_IMAGES):
 	@for f in $(DOCKER_IMAGES); do \
-		echo "Building Apptainer: $@"; \
-		apptainer pull docker-daemon:$(ORG_NAME)/$$f; \
+		echo "Building Apptainer: $$f"; \
+		apptainer pull docker-daemon:$(DOCKER_REPO)/$$f; \
 	done
 
 apptainer_clean:

--- a/src/test/admixture.sh
+++ b/src/test/admixture.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
+## SPDX-License-Identifier: GPL-2.0
 admixture --help

--- a/src/test/metal.sh
+++ b/src/test/metal.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
+# SPDX-License-Identifier: GPL-2.0
 metal -h

--- a/src/test/rfmix.sh
+++ b/src/test/rfmix.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
+# SPDX-License-Identifier: GPL-2.0
 rfmix --help


### PR DESCRIPTION
- place each package on its own line to facilitate diffs
- clean after package install (except on discarded builder)
- do not time-stamp the base image (to avoid rebuilds)
- migrate labels to bottom of Dockerfile to reduce rebuilds where time stamps are set
- install runtime dependencies in the base image first, so they can be discovered by any build configuration or dependency check (this - in some cases avoids building vendored libraries)
- include the runtime libraries in the base image where -dev libraries are included in the builder
- add entrypoints